### PR TITLE
fix: remover importação não utilizada do BiShoppingBag

### DIFF
--- a/src/app/components/Home/CarouselTechnology/CarouselTechnologyCard.tsx
+++ b/src/app/components/Home/CarouselTechnology/CarouselTechnologyCard.tsx
@@ -1,7 +1,6 @@
 import React from "react";
 import Image from "next/image";
 import { FaStar } from "react-icons/fa6";
-import { BiShoppingBag } from "react-icons/bi";
 
 // Atualizando a interface para incluir 'description'
 interface Props {


### PR DESCRIPTION
Removido o ícone BiShoppingBag não utilizado no componente CarouselTechnologyCard para corrigir o erro de linting.